### PR TITLE
Release v1.1.0: changelog, contributing guide, version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,43 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.1.0] - 2026-06-04
+
+### Added
+- `pyproject.toml` with packaging metadata, an `az-mapper` console-script entry
+  point, a `dev` extras group, and pylint configuration.
+- Tests for `--list-regions`, the `main()` stdout and file-output paths, and CSV
+  special-character quoting.
+- `CHANGELOG.md` and `CONTRIBUTING.md`.
+
+### Changed
+- CSV output now uses the standard-library `csv` module, so values containing
+  commas, quotes, or newlines are correctly quoted and escaped.
+- Output filename timestamps now use UTC for cross-machine consistency.
+- The pylint workflow is aligned with the test workflow: `checkout@v4`,
+  `setup-python@v5`, a Python 3.9-3.12 matrix, and `main`/pull-request triggers
+  only. `setup-python` was also bumped to v5 in the test workflow.
+
+### Removed
+- Support for end-of-life Python 3.8; the project now requires Python 3.9 or
+  higher.
+
+### Fixed
+- Region discovery now warns loudly when it falls back to the hardcoded region
+  list, which may be stale or include regions the account cannot access.
+
+## [1.0.0] - 2026-05-04
+
+### Added
+- Initial stable release: map AWS logical availability zones to physical zone
+  IDs for the currently authenticated account.
+- Non-interactive CLI with JSON and CSV output, region filtering, `--stdout`,
+  `--quiet`, and `--list-regions`.
+- Testing infrastructure and GitHub Actions workflows for tests and pylint.
+
+[1.1.0]: https://github.com/jbarnes/aws-az-mapper/compare/v1.0.0...v1.1.0
+[1.0.0]: https://github.com/jbarnes/aws-az-mapper/releases/tag/v1.0.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,44 @@
+# Contributing
+
+Thanks for your interest in improving aws-az-mapper. Issues and pull requests are
+welcome.
+
+## Development setup
+
+Requires Python 3.9 or higher and AWS CLI credentials only if you want to run the
+tool against a real account (the test suite mocks all AWS calls).
+
+```bash
+python3 -m venv venv
+source venv/bin/activate
+make install   # installs runtime + dev dependencies (pytest, pylint)
+```
+
+## Running tests and linting
+
+```bash
+make test   # pytest tests/ -v
+make lint   # pylint az_mapper.py --fail-under=9.0
+```
+
+Tests use `pytest` with mocked AWS API calls, so no AWS credentials are required.
+
+## Pull request guidelines
+
+- Branch off `main` and open a pull request against `main`.
+- Keep changes focused; one logical change per pull request where practical.
+- Add or update tests for any behaviour change.
+- CI must pass on all supported Python versions (3.9-3.12). This runs both the
+  test suite and pylint; the pylint score must stay at or above 9.0.
+- Update `CHANGELOG.md` under an `## [Unreleased]` heading (create it if needed)
+  describing your change.
+
+## Releasing
+
+Releases follow [Semantic Versioning](https://semver.org/). To cut a release:
+
+1. Move the `Unreleased` changelog entries under a new version heading with the
+   release date, and update the comparison links at the bottom of the file.
+2. Bump `version` in `pyproject.toml`.
+3. Tag the merge commit on `main` (`git tag -a vX.Y.Z`) and push the tag.
+4. Publish a GitHub release from the tag.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aws-az-mapper"
-version = "0.1.0"
+version = "1.1.0"
 description = "Map AWS logical availability zones to physical zone IDs for the current account"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
Prepares the v1.1.0 release.

- Add `CHANGELOG.md` (Keep a Changelog format) covering v1.0.0 and v1.1.0.
- Add `CONTRIBUTING.md` with dev setup, test/lint commands, PR guidelines, and release steps.
- Bump `pyproject.toml` version 0.1.0 -> 1.1.0 to match the release tag.

The v1.1.0 tag and GitHub release will be created from the merge commit on main.