### PR TITLE
Test against Python 3.13 and 3.14 in CI

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
     - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   commas, quotes, or newlines are correctly quoted and escaped.
 - Output filename timestamps now use UTC for cross-machine consistency.
 - The pylint workflow is aligned with the test workflow: `checkout@v4`,
-  `setup-python@v5`, a Python 3.9-3.12 matrix, and `main`/pull-request triggers
+  `setup-python@v5`, a Python 3.9-3.14 matrix, and `main`/pull-request triggers
   only. `setup-python` was also bumped to v5 in the test workflow.
+- CI now tests against Python 3.13 and 3.14 in addition to 3.9-3.12.
 
 ### Removed
 - Support for end-of-life Python 3.8; the project now requires Python 3.9 or


### PR DESCRIPTION
Extends the test and pylint CI matrices to cover Python 3.13 and 3.14, which have been released since the matrix was last set (it stopped at 3.12).

No source changes; `requires-python = ">=3.9"` already covers newer versions. Changelog updated to reflect the broader matrix.